### PR TITLE
Feat (recovery-codes): add display recovery codes step handler

### DIFF
--- a/src/basic/handlers/display-recovery-codes.ts
+++ b/src/basic/handlers/display-recovery-codes.ts
@@ -1,0 +1,61 @@
+import { FRStep, FRRecoveryCodes } from '@forgerock/javascript-sdk';
+import { FRUIStepHandler } from '../../interfaces';
+import Deferred from '../../util/deferred';
+import { el } from '../../util/dom';
+import template from '../views/list.html';
+
+class DisplayRecoveryCodes implements FRUIStepHandler {
+  private buttons!: HTMLDivElement;
+  private header!: HTMLDivElement;
+  private container!: HTMLDivElement;
+  protected deferred: Deferred<FRStep>;
+
+  constructor(private target: HTMLElement, private step: FRStep) {
+    this.target.innerHTML = template;
+
+    const buttonsEl = this.target.querySelector<HTMLDivElement>('.fr-buttons');
+    const headerEl = this.target.querySelector<HTMLDivElement>('h1');
+    const containerEl = this.target.querySelector<HTMLDivElement>('.fr-list-container');
+
+    if (!buttonsEl || !headerEl || !containerEl) {
+      throw new Error(`Required targets not found for display recovery codes handler view`);
+    }
+
+    this.buttons = buttonsEl;
+    this.header = headerEl;
+    this.container = containerEl;
+
+    this.deferred = new Deferred<FRStep>();
+  }
+
+  public completeStep = (): Promise<FRStep> => {
+    this.header.innerHTML = 'Your Recovery Codes';
+
+    const recoveryCodes = FRRecoveryCodes.getCodes(this.step);
+    const listHTML = recoveryCodes.reduce((prev: string, curr: string): string => {
+      prev = `${prev}<li class="fr-recovery-code">${curr}</li>`;
+      return prev;
+    }, '');
+    this.container.innerHTML = `
+    <p>
+      You must save a copy of these recovery codes. They cannot be displayed again.
+    </p>
+    <ul class="fr-list">
+      ${listHTML}
+    </ul>
+    <p>
+      Use one of these codes to authenticate if you lose your device
+    </p>
+    `;
+
+    const button = el<HTMLButtonElement>('button', 'btn btn-primary');
+    button.id = 'fr-submit';
+    button.innerText = 'Next';
+    button.addEventListener('click', () => this.deferred.resolve(this.step));
+    this.buttons.appendChild(button);
+
+    return this.deferred.promise;
+  };
+}
+
+export default DisplayRecoveryCodes;

--- a/src/basic/index.ts
+++ b/src/basic/index.ts
@@ -1,8 +1,15 @@
-import { CallbackType, FRStep, FRWebAuthn, WebAuthnStepType } from '@forgerock/javascript-sdk';
+import {
+  CallbackType,
+  FRStep,
+  FRRecoveryCodes,
+  FRWebAuthn,
+  WebAuthnStepType,
+} from '@forgerock/javascript-sdk';
 import { FRUIStepHandlerFactory } from '../interfaces';
 import { WebAuthnMode } from './enums';
 import BasicStepHandler from './handlers/basic';
 import DeviceStepHandler from './handlers/device-profile';
+import DisplayRecoveryCodes from './handlers/display-recovery-codes';
 import WebAuthnStepHandler from './handlers/webauthn';
 import { CallbackRendererFactory } from './interfaces';
 
@@ -27,6 +34,11 @@ const basicStepHandlerFactory: FRUIStepHandlerFactory = (
     const isAuth = webAuthnStepType === WebAuthnStepType.Authentication;
     const webAuthnMode = isAuth ? WebAuthnMode.Authentication : WebAuthnMode.Registration;
     return new WebAuthnStepHandler(target, step, webAuthnMode);
+  }
+
+  const isDisplayRecoveryCodesStep = FRRecoveryCodes.isDisplayStep(step); // returns boolean
+  if (isDisplayRecoveryCodesStep) {
+    return new DisplayRecoveryCodes(target, step);
   }
 
   const deviceProfileStep = step.getCallbacksOfType(CallbackType.DeviceProfileCallback);

--- a/src/basic/views/list.html
+++ b/src/basic/views/list.html
@@ -1,0 +1,9 @@
+<main class="fr-step">
+  <section class="fr-main">
+    <header class="fr-header">
+      <h1></h1>
+    </header>
+    <section class="fr-list-container"></section>
+    <div class="fr-buttons"></div>
+  </section>
+</main>

--- a/src/css/sdk/_header.scss
+++ b/src/css/sdk/_header.scss
@@ -13,7 +13,7 @@
 
   & > h1 {
     font-size: 28px;
-    margin: 0.5em;
+    margin-bottom: 0.5em;
   }
 
   & > h2 {

--- a/src/css/sdk/_list.scss
+++ b/src/css/sdk/_list.scss
@@ -1,5 +1,5 @@
 .fr-list {
-  margin: 0;
+  margin: 0 0 1rem 0;
   padding: 0;
 }
 
@@ -33,4 +33,14 @@
 .fr-icon-list-sms {
   background: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8' standalone='no'%3F%3E%3Csvg xmlns:dc='http://purl.org/dc/elements/1.1/' xmlns:cc='http://creativecommons.org/ns%23' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns%23' xmlns:svg='http://www.w3.org/2000/svg' xmlns='http://www.w3.org/2000/svg' xmlns:sodipodi='http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd' xmlns:inkscape='http://www.inkscape.org/namespaces/inkscape' width='21' height='23' viewBox='0 0 21 23' version='1.1' id='svg4' sodipodi:docname='list-text.svg' style='fill:none' inkscape:version='0.92.4 5da689c313, 2019-01-14'%3E%3Cmetadata id='metadata10'%3E%3Crdf:RDF%3E%3Ccc:Work rdf:about=''%3E%3Cdc:format%3Eimage/svg+xml%3C/dc:format%3E%3Cdc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage' /%3E%3Cdc:title%3E%3C/dc:title%3E%3C/cc:Work%3E%3C/rdf:RDF%3E%3C/metadata%3E%3Cdefs id='defs8' /%3E%3Csodipodi:namedview pagecolor='%23ffffff' bordercolor='%23666666' borderopacity='1' objecttolerance='10' gridtolerance='10' guidetolerance='10' inkscape:pageopacity='0' inkscape:pageshadow='2' inkscape:window-width='1333' inkscape:window-height='1363' id='namedview6' showgrid='false' inkscape:zoom='10.20239' inkscape:cx='15.96166' inkscape:cy='5.7125499' inkscape:window-x='2077' inkscape:window-y='47' inkscape:window-maximized='0' inkscape:current-layer='layer3' /%3E%3Cg inkscape:groupmode='layer' id='layer1' inkscape:label='Layer 1' style='display:none'%3E%3Cg style='fill:none' id='g23' transform='translate(0.2402545,-0.4999875)'%3E%3Cpath id='path12' d='m 18.3691,7.6875 c 1.25,1.21875 1.875,2.6563 1.875,4.3125 0,1.6562 -0.625,3.0625 -1.875,4.2188 l -0.9843,-1.0313 c 0.9062,-0.9375 1.3593,-2.0313 1.3593,-3.2813 0,-1.25 -0.4531,-2.31245 -1.3593,-3.18745 z m -2.1093,2.10938 c 0.625,0.65622 0.9375,1.39062 0.9375,2.20312 0,0.8125 -0.3125,1.5156 -0.9375,2.1094 l -0.9844,-1.0313 c 0.5625,-0.75 0.5625,-1.5156 0,-2.2969 z M 12.2754,0.984375 c 0.5625,0 1.0312,0.203125 1.4062,0.609375 C 14.0879,1.96875 14.291,2.4375 14.291,3 v 18 c 0,0.5625 -0.2031,1.0312 -0.6094,1.4062 -0.375,0.4063 -0.8437,0.6094 -1.4062,0.6094 H 2.29102 c -0.5625,0 -1.04688,-0.2031 -1.453129,-0.6094 -0.375,-0.375 -0.5625,-0.8437 -0.5625,-1.4062 V 3 c 0,-0.5625 0.1875,-1.03125 0.5625,-1.40625 C 1.24414,1.1875 1.72852,0.984375 2.29102,0.984375 Z m 0,19.031225 V 3.98438 H 2.29102 V 20.0156 Z' inkscape:connector-curvature='0' style='fill:%23455469' /%3E%3C/g%3E%3C/g%3E%3Cg inkscape:groupmode='layer' id='layer2' inkscape:label='Layer 2' style='display:inline'%3E%3Cg style='fill:none' id='g49' transform='translate(0.2402235,1.4999875)'%3E%3Cpath id='path38' d='m 18.252,0.015625 c 0.5625,0 1.0312,0.203125 1.4062,0.609375 0.4063,0.375 0.6094,0.82812 0.6094,1.35938 V 13.9844 c 0,0.5625 -0.2031,1.0468 -0.6094,1.4531 C 19.2832,15.8125 18.8145,16 18.252,16 H 4.23633 L 0.251953,19.9844 V 1.98438 C 0.251953,1.45312 0.439453,1 0.814453,0.625 1.2207,0.21875 1.70508,0.015625 2.26758,0.015625 Z M 7.23633,9.01562 V 7 H 5.26758 v 2.01562 z m 4.03127,0 V 7 H 9.25195 v 2.01562 z m 3.9844,0 V 7 h -2.0157 v 2.01562 z' inkscape:connector-curvature='0' style='fill:%23455469' /%3E%3C/g%3E%3C/g%3E%3Cg inkscape:groupmode='layer' id='layer3' inkscape:label='Layer 3' style='display:none'%3E%3Cg style='fill:none' id='g36' transform='translate(0.2402235,2.5000125)'%3E%3Cpath id='path25' d='m 18.252,0.984375 c 0.5625,0 1.0312,0.203125 1.4062,0.609375 0.4063,0.375 0.6094,0.84375 0.6094,1.40625 v 12 c 0,0.5625 -0.2031,1.0469 -0.6094,1.4531 -0.375,0.375 -0.8437,0.5625 -1.4062,0.5625 H 2.26758 c -0.5625,0 -1.04688,-0.1875 -1.453127,-0.5625 -0.375,-0.4062 -0.5625,-0.8906 -0.5625,-1.4531 V 3 c 0,-0.5625 0.1875,-1.03125 0.5625,-1.40625 C 1.2207,1.1875 1.70508,0.984375 2.26758,0.984375 Z m 0,4.031245 V 3 L 10.2363,8.01562 2.26758,3 v 2.01562 l 7.96872,4.96876 z' inkscape:connector-curvature='0' style='fill:%23455469' /%3E%3C/g%3E%3C/g%3E%3C/svg%3E%0A")
     1.25em center no-repeat;
+}
+
+.fr-recovery-code {
+  list-style: none;
+
+  &:before {
+    content: '☐';
+    padding-right: 0.5rem;
+    font-size: 1.25em;
+  }
 }

--- a/tests/e2e/app/authn-device-profile/index.html
+++ b/tests/e2e/app/authn-device-profile/index.html
@@ -44,8 +44,6 @@
       const frui = new forgerock.FRUI();
       const result = await frui.getSession();
 
-      console.log(result);
-
       if (result.type === 'LoginSuccess') {
         target.innerHTML = `Success:<br/>${result.getSessionToken()}<br/><br/>Logging out in 3 seconds...`;
         setTimeout(async () => {

--- a/tests/e2e/app/authn-webauthn/index.html
+++ b/tests/e2e/app/authn-webauthn/index.html
@@ -31,7 +31,7 @@
       const realmPath = url.searchParams.get('realmPath') || 'root';
       const un = url.searchParams.get('un') || '57a5b4e4-6999-4b45-bf86-a4f2e5d4b629';
       const pw = url.searchParams.get('pw') || 'ieH034K&-zlwqh3V_';
-      const tree = url.searchParams.get('tree') || 'UsernamePassword';
+      const tree = url.searchParams.get('tree') || 'PasswordlessWebAuthn';
 
       forgerock.Config.set({
         serverConfig: {

--- a/tests/e2e/app/index.html
+++ b/tests/e2e/app/index.html
@@ -16,6 +16,7 @@
         </p>
         <p><a href="./authn-basic" class="btn btn-primary">Basic Auth</a></p>
         <p><a href="./authn-device-profile" class="btn btn-primary">Basic Auth with Device Profile</a></p>
+        <p><a href="./authn-webauthn" class="btn btn-primary">Passwordless WebAuthn</a></p>
         <p><a href="./authn-oauth" class="btn btn-primary">OAuth 2.0</a></p>
       </div>
     </div>


### PR DESCRIPTION
**Summary**:

The "Display Recovery Code" node returns to the client a TextOutputCallback with a message text that has JavaScript in it that embeds the recovery codes. Providing a step handler to get the recovery codes and display them appropriately.

**Details**:

- Provide a step handler for "Display Recovery Codes" step
- Adjust styles to handle the codes for ease of reading and usability

**Screen recording**:

![recovery-codes](https://user-images.githubusercontent.com/3070458/88238250-c732e580-cc46-11ea-9a7e-8ffb31186b6b.gif)

**Dependencies**:

- [ ] This PR must be merged and changes published: https://github.com/ForgeRock/forgerock-javascript-sdk/pull/73